### PR TITLE
chore: release

### DIFF
--- a/crates/hw_dcmi_wrapper/CHANGELOG.md
+++ b/crates/hw_dcmi_wrapper/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper-v0.0.3...hw_dcmi_wrapper-v0.0.4) - 2025-03-16
+
+### Added
+
+- [**breaking**] `DCMI` not implemented `Sync` anymore ([#9](https://github.com/ZhuLegend/hw_dcmi_wrapper/pull/9))
+- *(build)* add environment variable rerun condition for DCMI path
+
+### Other
+
+- update documentation formatting and links
+
 ## [0.0.3](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper-v0.0.2...hw_dcmi_wrapper-v0.0.3) - 2025-02-07
 
 ### Fixed

--- a/crates/hw_dcmi_wrapper/Cargo.toml
+++ b/crates/hw_dcmi_wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hw_dcmi_wrapper"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["ZhuLegend"]
 description = "A safe and ergonomic Rust wrapper for the Huawei DCMI API."
 readme = "../../README.md"
@@ -24,4 +24,4 @@ libloading = { workspace = true, optional = true }
 
 static_assertions = "1.1.0"
 
-hw_dcmi_wrapper_sys = { version = "0.1.2", path = "../hw_dcmi_wrapper_sys" }
+hw_dcmi_wrapper_sys = { version = "0.1.3", path = "../hw_dcmi_wrapper_sys" }

--- a/crates/hw_dcmi_wrapper_sys/CHANGELOG.md
+++ b/crates/hw_dcmi_wrapper_sys/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper_sys-v0.1.2...hw_dcmi_wrapper_sys-v0.1.3) - 2025-03-16
+
+### Added
+
+- *(build)* add environment variable rerun condition for DCMI path
+
+### Other
+
+- update documentation formatting and links
+
 ## [0.1.2](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper_sys-v0.1.1...hw_dcmi_wrapper_sys-v0.1.2) - 2025-02-07
 
 ### Fixed

--- a/crates/hw_dcmi_wrapper_sys/Cargo.toml
+++ b/crates/hw_dcmi_wrapper_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hw_dcmi_wrapper_sys"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["ZhuLegend"]
 description = "A raw FFI binding to the Huawei DCMI API."
 readme = "./README.md"


### PR DESCRIPTION



## 🤖 New release

* `hw_dcmi_wrapper_sys`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `hw_dcmi_wrapper`: 0.0.3 -> 0.0.4 (⚠ API breaking changes)

### ⚠ `hw_dcmi_wrapper` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Chip is no longer Send, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/chip.rs:15
  type Chip is no longer Sync, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/chip.rs:15
  type Chip is no longer UnwindSafe, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/chip.rs:15
  type Chip is no longer RefUnwindSafe, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/chip.rs:15
  type Card is no longer Send, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/card.rs:10
  type Card is no longer Sync, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/card.rs:10
  type Card is no longer UnwindSafe, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/card.rs:10
  type Card is no longer RefUnwindSafe, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/card.rs:10
  type VChip is no longer Send, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/vchip.rs:11
  type VChip is no longer Sync, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/vchip.rs:11
  type VChip is no longer UnwindSafe, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/vchip.rs:11
  type VChip is no longer RefUnwindSafe, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/device/vchip.rs:11
  type DCMI is no longer Sync, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/lib.rs:106
  type DCMI is no longer RefUnwindSafe, in /tmp/.tmpftIFkC/hw_dcmi_wrapper/crates/hw_dcmi_wrapper/src/lib.rs:106
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `hw_dcmi_wrapper_sys`

<blockquote>

## [0.1.3](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper_sys-v0.1.2...hw_dcmi_wrapper_sys-v0.1.3) - 2025-03-16

### Added

- *(build)* add environment variable rerun condition for DCMI path

### Other

- update documentation formatting and links
</blockquote>

## `hw_dcmi_wrapper`

<blockquote>

## [0.0.4](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper-v0.0.3...hw_dcmi_wrapper-v0.0.4) - 2025-03-16

### Added

- [**breaking**] `DCMI` not implemented `Sync` anymore ([#9](https://github.com/ZhuLegend/hw_dcmi_wrapper/pull/9))
- *(build)* add environment variable rerun condition for DCMI path

### Other

- update documentation formatting and links
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).