### PR TITLE
feat(bindings)!: add optional bindgen feature for regenerating bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Huawei DCMI. This repository contains two main packages:
 By default, the library searches for DCMI components in the `/usr/local/dcmi` directory.
 You can override this path by setting the `HW_DCMI_PATH` environment variable.
 
-If you want to regenerate bindings, you can set `HW_DCMI_BINDING_BUILD` to `true` to regenerate bindings,
-the generated bindings will be saved in:
+If you want to regenerate bindings, you can set `HW_DCMI_BINDING_BUILD` to `true` and
+enable feature `bindgen` to regenerate bindings, the generated bindings will be saved in:
 
 - Static link: `hw_dcmi_wrapper_sys/src/bindings.rs`
 - Dynamic link: `hw_dcmi_wrapper_sys/src/bindings_dyn.rs`

--- a/README_CN.md
+++ b/README_CN.md
@@ -21,7 +21,7 @@
 默认情况下，库将尝试在`/usr/local/dcmi`中查找`dcmi_interface_api.h`并链接`libdcmi.so`，
 你可以提供`HW_DCMI_PATH`环境变量来指定dcmi共享库的路径。
 
-如需重新生成绑定，请设置环境变量`HW_DCMI_BINDING_BUILD`为`true`，生成的绑定文件将保存至：
+如需重新生成绑定，请设置环境变量`HW_DCMI_BINDING_BUILD`为`true`，并为库启用`bindgen` feature，生成的绑定文件将保存至：
 
 - 静态链接：`hw_dcmi_wrapper_sys/src/bindings.rs`
 - 动态链接：`hw_dcmi_wrapper_sys/src/bindings_dyn.rs`

--- a/crates/hw_dcmi_wrapper/Cargo.toml
+++ b/crates/hw_dcmi_wrapper/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["api-bindings", "development-tools::ffi", "hardware-support"]
 [features]
 load_dynamic = ["hw_dcmi_wrapper_sys/load_dynamic", "dep:libloading"]
 serde = ["dep:serde", "serde/derive"]
+bindgen = ["hw_dcmi_wrapper_sys/bindgen"]
 
 [dependencies]
 thiserror = "1.0"

--- a/crates/hw_dcmi_wrapper_sys/Cargo.toml
+++ b/crates/hw_dcmi_wrapper_sys/Cargo.toml
@@ -16,7 +16,8 @@ categories = ["external-ffi-bindings", "hardware-support"]
 libloading = { workspace = true, optional = true }
 
 [build-dependencies]
-bindgen = "0.70.1"
+bindgen = { version = "0.72.0", optional = true }
 
 [features]
 load_dynamic = ["dep:libloading"]
+bindgen = ["dep:bindgen"]

--- a/crates/hw_dcmi_wrapper_sys/build.rs
+++ b/crates/hw_dcmi_wrapper_sys/build.rs
@@ -1,6 +1,6 @@
 use std::env;
-use std::path::PathBuf;
 
+#[cfg(feature = "bindgen")]
 fn init_bindgen_builder(header: impl Into<String>) -> bindgen::Builder {
     bindgen::Builder::default()
         // The input header we would like to generate bindings for.
@@ -24,42 +24,46 @@ fn main() {
     #[cfg(not(feature = "load_dynamic"))]
     println!("cargo:rustc-link-lib=dylib=dcmi");
 
-    // 当且仅当HW_DCMI_BINDING_BUILD为true时才生成绑定
-    println!("cargo:rerun-if-env-changed=HW_DCMI_BINDING_BUILD");
-    if env::var("HW_DCMI_BINDING_BUILD").is_err() {
-        return;
+    #[cfg(feature = "bindgen")]
+    {
+        // 当且仅当HW_DCMI_BINDING_BUILD为true时才生成绑定
+        println!("cargo:rerun-if-env-changed=HW_DCMI_BINDING_BUILD");
+        if env::var("HW_DCMI_BINDING_BUILD").is_err() {
+            return;
+        }
+        if env::var("HW_DCMI_BINDING_BUILD").unwrap() != "true" {
+            return;
+        }
+
+        let interface_path = format!("{}/dcmi_interface_api.h", hw_dcmi_path);
+
+        // The bindgen::Builder is the main entry point to bindgen,
+        // and lets you build up options for the resulting bindings.
+
+        let builder = init_bindgen_builder(interface_path);
+
+        #[cfg(feature = "load_dynamic")]
+        let builder = builder
+            .dynamic_library_name("dcmi")
+            .dynamic_link_require_all(true);
+
+        let bindings = builder
+            // Finish the builder and generate the bindings.
+            .generate()
+            // Unwrap the Result and panic on failure.
+            .expect("Unable to generate bindings");
+
+        // 指定输出文件的路径为 src/hw_dcmi_wrapper_sys.rs
+        #[cfg(feature = "load_dynamic")]
+        let out_path =
+            PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("src/bindings_dyn.rs");
+        #[cfg(not(feature = "load_dynamic"))]
+        let out_path =
+            PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("src/bindings.rs");
+
+        // Write the bindings to the specified file.
+        bindings
+            .write_to_file(out_path)
+            .expect("Couldn't write bindings!");
     }
-    if env::var("HW_DCMI_BINDING_BUILD").unwrap() != "true" {
-        return;
-    }
-
-    let interface_path = format!("{}/dcmi_interface_api.h", hw_dcmi_path);
-
-    // The bindgen::Builder is the main entry point to bindgen,
-    // and lets you build up options for the resulting bindings.
-
-    let builder = init_bindgen_builder(interface_path);
-
-    #[cfg(feature = "load_dynamic")]
-    let builder = builder
-        .dynamic_library_name("dcmi")
-        .dynamic_link_require_all(true);
-
-    let bindings = builder
-        // Finish the builder and generate the bindings.
-        .generate()
-        // Unwrap the Result and panic on failure.
-        .expect("Unable to generate bindings");
-
-    // 指定输出文件的路径为 src/hw_dcmi_wrapper_sys.rs
-    #[cfg(feature = "load_dynamic")]
-    let out_path =
-        PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("src/bindings_dyn.rs");
-    #[cfg(not(feature = "load_dynamic"))]
-    let out_path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("src/bindings.rs");
-
-    // Write the bindings to the specified file.
-    bindings
-        .write_to_file(out_path)
-        .expect("Couldn't write bindings!");
 }


### PR DESCRIPTION
Update build script to conditionally generate bindings only when the `bindgen` feature is enabled and `HW_DCMI_BINDING_BUILD` is set to true.
Make bindgen an optional dependency and add corresponding feature flags in Cargo.toml.
Clarify README instructions to require enabling the `bindgen` feature for binding.

BREAKING CHANGE: add optional bindgen feature for regenerating bindings, not require bindgen as deps for most users