### PR TITLE
chore: release

### DIFF
--- a/crates/hw_dcmi_wrapper/CHANGELOG.md
+++ b/crates/hw_dcmi_wrapper/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper-v0.0.4...hw_dcmi_wrapper-v0.0.5) - 2025-06-22
+
+### Added
+
+- *(bindings)* [**breaking**] add optional bindgen feature for regenerating bindings ([#10](https://github.com/ZhuLegend/hw_dcmi_wrapper/pull/10))
+
+### Fixed
+
+- *(test)* add mutex to DCMI_INSTANCE for thread safety ([#11](https://github.com/ZhuLegend/hw_dcmi_wrapper/pull/11))
+
 ## [0.0.4](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper-v0.0.3...hw_dcmi_wrapper-v0.0.4) - 2025-03-16
 
 ### Added

--- a/crates/hw_dcmi_wrapper/Cargo.toml
+++ b/crates/hw_dcmi_wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hw_dcmi_wrapper"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["ZhuLegend"]
 description = "A safe and ergonomic Rust wrapper for the Huawei DCMI API."
 readme = "../../README.md"
@@ -25,4 +25,4 @@ libloading = { workspace = true, optional = true }
 
 static_assertions = "1.1.0"
 
-hw_dcmi_wrapper_sys = { version = "0.1.3", path = "../hw_dcmi_wrapper_sys" }
+hw_dcmi_wrapper_sys = { version = "0.2.0", path = "../hw_dcmi_wrapper_sys" }

--- a/crates/hw_dcmi_wrapper_sys/CHANGELOG.md
+++ b/crates/hw_dcmi_wrapper_sys/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper_sys-v0.1.3...hw_dcmi_wrapper_sys-v0.2.0) - 2025-06-22
+
+### Added
+
+- *(bindings)* [**breaking**] add optional bindgen feature for regenerating bindings ([#10](https://github.com/ZhuLegend/hw_dcmi_wrapper/pull/10))
+
 ## [0.1.3](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper_sys-v0.1.2...hw_dcmi_wrapper_sys-v0.1.3) - 2025-03-16
 
 ### Added

--- a/crates/hw_dcmi_wrapper_sys/Cargo.toml
+++ b/crates/hw_dcmi_wrapper_sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hw_dcmi_wrapper_sys"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["ZhuLegend"]
 description = "A raw FFI binding to the Huawei DCMI API."
 readme = "./README.md"


### PR DESCRIPTION



## 🤖 New release

* `hw_dcmi_wrapper_sys`: 0.1.3 -> 0.2.0 (✓ API compatible changes)
* `hw_dcmi_wrapper`: 0.0.4 -> 0.0.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `hw_dcmi_wrapper_sys`

<blockquote>

## [0.2.0](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper_sys-v0.1.3...hw_dcmi_wrapper_sys-v0.2.0) - 2025-06-22

### Added

- *(bindings)* [**breaking**] add optional bindgen feature for regenerating bindings ([#10](https://github.com/ZhuLegend/hw_dcmi_wrapper/pull/10))
</blockquote>

## `hw_dcmi_wrapper`

<blockquote>

## [0.0.5](https://github.com/ZhuLegend/hw_dcmi_wrapper/compare/hw_dcmi_wrapper-v0.0.4...hw_dcmi_wrapper-v0.0.5) - 2025-06-22

### Added

- *(bindings)* [**breaking**] add optional bindgen feature for regenerating bindings ([#10](https://github.com/ZhuLegend/hw_dcmi_wrapper/pull/10))

### Fixed

- *(test)* add mutex to DCMI_INSTANCE for thread safety ([#11](https://github.com/ZhuLegend/hw_dcmi_wrapper/pull/11))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).