### PR TITLE
chore(deps): add cargo to dependabot weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Enable Dependabot to check Rust/Cargo dependencies weekly by adding a cargo package-ecosystem entry to .github/dependabot.yml.
This ensures automated weekly updates for Cargo crates alongside existing package managers, improving dependency maintenance and security patching for Rust components.