### PR TITLE
feat: fail build on non-Linux platforms and document support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Huawei DCMI. This repository contains two main packages:
 2. **hw_dcmi_wrapper_sys**: Offers low-level, unsafe bindings that provide direct access to the underlying DCMI system
    calls.
 
+## Platform Support
+
+**Important: This library only supports Linux platforms.**
+
+- ✅ **Linux**: Full support
+- ❌ **macOS**: Not supported  
+- ❌ **Windows**: Not supported
+
+The Huawei DCMI API is only available on Linux systems. Attempting to compile this crate on other platforms will result in a build error.
+
 ## Getting Started
 
 ### Prerequisites

--- a/README_CN.md
+++ b/README_CN.md
@@ -9,6 +9,16 @@
 - hw_dcmi_wrapper提供safe的FFI绑定(由hw_dcmi_sys提供的FFI绑定封装而成)
 - hw_dcmi_wrapper_sys提供unsafe的FFI绑定(由bindgen直接生成)
 
+## 平台支持
+
+**重要：此库仅支持 Linux 平台。**
+
+- ✅ **Linux**: 完全支持
+- ❌ **macOS**: 不支持  
+- ❌ **Windows**: 不支持
+
+华为 DCMI API 仅在 Linux 系统上可用。尝试在其他平台上编译此 crate 将导致构建错误。
+
 ## 使用方法
 
 ### 先决条件

--- a/crates/hw_dcmi_wrapper/build.rs
+++ b/crates/hw_dcmi_wrapper/build.rs
@@ -1,0 +1,21 @@
+fn main() {
+    // 检查当前编译平台是否为 Linux
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    if target_os != "linux" {
+        eprintln!();
+        eprintln!("错误: hw_dcmi_wrapper 只支持 Linux 平台");
+        eprintln!("Error: hw_dcmi_wrapper only supports Linux platforms");
+        eprintln!();
+        eprintln!("当前目标平台: {}", target_os);
+        eprintln!("Current target platform: {}", target_os);
+        eprintln!();
+        eprintln!("华为 DCMI API 仅在 Linux 系统上可用。");
+        eprintln!("Huawei DCMI API is only available on Linux systems.");
+        eprintln!();
+
+        std::process::exit(1);
+    }
+
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+}

--- a/crates/hw_dcmi_wrapper_sys/build.rs
+++ b/crates/hw_dcmi_wrapper_sys/build.rs
@@ -16,6 +16,26 @@ fn init_bindgen_builder(header: impl Into<String>) -> bindgen::Builder {
 }
 
 fn main() {
+    // 检查当前编译平台是否为 Linux
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    if target_os != "linux" {
+        eprintln!();
+        eprintln!("错误: hw_dcmi_wrapper_sys 只支持 Linux 平台");
+        eprintln!("Error: hw_dcmi_wrapper_sys only supports Linux platforms");
+        eprintln!();
+        eprintln!("当前目标平台: {}", target_os);
+        eprintln!("Current target platform: {}", target_os);
+        eprintln!();
+        eprintln!("华为 DCMI API 仅在 Linux 系统上可用。");
+        eprintln!("Huawei DCMI API is only available on Linux systems.");
+        eprintln!();
+
+        std::process::exit(1);
+    }
+
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+
     // 读取环境变量HW_DCMI_PATH作为库搜索路径
     println!("cargo:rerun-if-env-changed=HW_DCMI_PATH");
     let hw_dcmi_path = env::var("HW_DCMI_PATH").unwrap_or_else(|_| "/usr/local/dcmi".to_string());


### PR DESCRIPTION
Add platform checks to build scripts for hw_dcmi_wrapper and hw_dcmi_wrapper_sys to abort compilation when the target OS is not Linux.
The build.rs files now print clear bilingual (Chinese/English) error messages indicating the current target and that the Huawei DCMI API is only available on Linux, then exit with a non-zero status. 
Also emit cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS to ensure rebuilds when the target OS changes.